### PR TITLE
Parametrize buildkite codecov plugin docker image

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -75,7 +75,7 @@ main() {
       --volume=${codecov_bash_dir}/codecov:/codecov \
       -it \
       --rm \
-      buildpack-deps:jessie-scm \
+      ${BUILDKITE_PLUGIN_CODECOV_DOCKER_IMAGE} \
       bash -c "bash /codecov ${args[*]:-}"
   exit_code="$?"
   set -e


### PR DESCRIPTION
Parametrize buildkite codecov plugin docker image using BUILDKITE_PLUGIN_CODECOV_DOCKER_IMAGE env var