### PR TITLE
Add a missing plugin config setting

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -12,4 +12,6 @@ configuration:
       type: array
     skip_on_fail:
       type: boolean
+    docker_image:
+      type: string
   additionalProperties: false


### PR DESCRIPTION
CC @paymand 

Then you can release `v2.2.1` of the plugin and use it like this:

```
    peakon/codecov#v2.2.1:
      skip_on_fail: true
      args:
        - "-F $$BUILDKITE_JOB_ID"
      docker_image: 'public.ecr.aws/docker/library/buildpack-deps:jessie-scm'
```